### PR TITLE
SPAT-180 Enhance notification specifications

### DIFF
--- a/docs/features/notification/notifications.md
+++ b/docs/features/notification/notifications.md
@@ -6,9 +6,9 @@ sidebar_position: 3
 
 | Environment | status            |
 |-------------|-------------------|
-| Test        | 🚧 In development |
-| Acceptance  | 🛑 Unavailable    |
-| Production  | 🛑 Unavailable    |
+| Test        | ✅ Available      |
+| Acceptance  | ✅ Available      |
+| Production  | ✅ Available      |
 
 **API specifications:**
 * [API Spreekuur.nl](api-spreekuur.mdx)
@@ -59,8 +59,8 @@ The notification endpoint expects a FHIR `Communication` resource.
 
 At minimum, the request should contain:
 - `Communication.category` with a coding whose `code` is `notification`
-- `Communication.topic.text` with the subject shown to the patient
-- `Communication.payload[].contentString` with the message body
+- `Communication.topic.text` with the subject shown to the patient (max. 500 characters)
+- `Communication.payload[].contentString` with the message body (min. 1, max. 10.000 characters)
 - `Communication.recipient[].reference` pointing to the contained `Patient`
 - A contained `Patient` resource with a BSN in `Patient.identifier`
 
@@ -75,5 +75,7 @@ Spreekuur.nl validates whether the incoming `Communication` can be processed as 
 Requests are rejected when:
 - `Communication.category` is missing
 - `Communication.category` does not identify the resource as a notification
+- `Communication.topic.text` exceeds 500 characters
+- `Communication.payload[].contentString` is empty or exceeds 10.000 characters
 
 See the [API Spreekuur.nl](api-spreekuur.mdx) page for the public request schema.

--- a/openapi/spreekuur/notification-spreekuur.yaml
+++ b/openapi/spreekuur/notification-spreekuur.yaml
@@ -45,6 +45,7 @@ components:
           properties:
             text:
               type: string
+              maxLength: 500
               example: "Lab results available"
         status:
           type: string
@@ -75,6 +76,8 @@ components:
             properties:
               contentString:
                 type: string
+                minLength: 1
+                maxLength: 10000
                 example: "Your lab results are available."
         recipient:
           type: array


### PR DESCRIPTION
This pull request updates the documentation and OpenAPI specification for the notification feature to clarify and enforce new validation rules on message length. The changes ensure that both the documentation and API schema are aligned regarding the maximum length of notification subjects and the allowed range for message body length.

**Documentation updates:**

* Updated the environment status table in `notifications.md` to reflect that the notification feature is now available in Test, Acceptance, and Production environments.
* Clarified in `notifications.md` that `Communication.topic.text` is limited to 500 characters and `Communication.payload[].contentString` must be between 1 and 10,000 characters.
* Added explicit rejection criteria for requests where the subject or message body does not meet the new length requirements.

**OpenAPI specification updates:**

* Added a `maxLength: 500` constraint to the `text` property of `Communication.topic` in `notification-spreekuur.yaml`.
* Added `minLength: 1` and `maxLength: 10000` constraints to the `contentString` property of `Communication.payload` in `notification-spreekuur.yaml`.